### PR TITLE
Use browserify+brfs to build browser version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ browser:
 	echo ' * Licensed under the MIT license.'                                          >> $(BROWSER_FILE_DEV)
 	echo ' */'                                                                         >> $(BROWSER_FILE_DEV)
 
-	$(BROWSERIFY) --standalone PEG $(MAIN_FILE) >> $(BROWSER_FILE_DEV)
+	$(BROWSERIFY) --standalone PEG $(MAIN_FILE) --transform brfs >> $(BROWSER_FILE_DEV)
 
 	$(UGLIFYJS)                 \
 	  --mangle                  \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ NODE_MODULES_BIN_DIR = $(NODE_MODULES_DIR)/.bin
 
 # ===== Files =====
 
+MAIN_FILE = $(LIB_DIR)/peg.js
+
 PARSER_SRC_FILE = $(SRC_DIR)/parser.pegjs
 PARSER_OUT_FILE = $(LIB_DIR)/parser.js
 
@@ -25,8 +27,8 @@ VERSION_FILE = VERSION
 
 # ===== Executables =====
 
-NODE          = node
 JSHINT        = $(NODE_MODULES_BIN_DIR)/jshint
+BROWSERIFY    = $(NODE_MODULES_BIN_DIR)/browserify
 UGLIFYJS      = $(NODE_MODULES_BIN_DIR)/uglifyjs
 JASMINE_NODE  = $(NODE_MODULES_BIN_DIR)/jasmine-node
 PEGJS         = $(BIN_DIR)/pegjs
@@ -48,7 +50,18 @@ browser:
 	rm -f $(BROWSER_FILE_DEV)
 	rm -f $(BROWSER_FILE_MIN)
 
-	$(NODE) tools/build-browser.js > $(BROWSER_FILE_DEV)
+	# The following code is inspired by CoffeeScript's Cakefile.
+
+	echo '/*'                                                                          >> $(BROWSER_FILE_DEV)
+	echo " * PEG.js $(PEGJS_VERSION)"                                                  >> $(BROWSER_FILE_DEV)
+	echo ' *'                                                                          >> $(BROWSER_FILE_DEV)
+	echo ' * http://pegjs.org/'                                                        >> $(BROWSER_FILE_DEV)
+	echo ' *'                                                                          >> $(BROWSER_FILE_DEV)
+	echo ' * Copyright (c) 2010-2015 David Majda'                                      >> $(BROWSER_FILE_DEV)
+	echo ' * Licensed under the MIT license.'                                          >> $(BROWSER_FILE_DEV)
+	echo ' */'                                                                         >> $(BROWSER_FILE_DEV)
+
+	$(BROWSERIFY) --standalone PEG $(MAIN_FILE) >> $(BROWSER_FILE_DEV)
 
 	$(UGLIFYJS)                 \
 	  --mangle                  \

--- a/lib/compiler/passes/ast-to-regalloc-js.js
+++ b/lib/compiler/passes/ast-to-regalloc-js.js
@@ -4,8 +4,8 @@ var arrays  = require("../../utils/arrays"),
     js      = require("../javascript"),
     visitor = require("../visitor"),
     objects = require('../../utils/objects'),
-    asts    = require("../asts"),
-    fs      = require("fs");
+    asts    = require("../asts");
+var fs      = require("fs");
 
 function initCache(opts) {
   return 'var peg$resultsCache = {}';

--- a/lib/compiler/passes/ast-to-regalloc-js.js
+++ b/lib/compiler/passes/ast-to-regalloc-js.js
@@ -4,15 +4,8 @@ var arrays  = require("../../utils/arrays"),
     js      = require("../javascript"),
     visitor = require("../visitor"),
     objects = require('../../utils/objects'),
-    asts    = require("../asts");
-
-if (typeof window === 'undefined') {
-  var fs = require('fs');
-  var readSource = function (moduleName) {
-    var fileName = __dirname + '/' + moduleName + '.js';
-    return fs.readFileSync(fileName, 'utf8');
-  };
-}
+    asts    = require("../asts"),
+    fs      = require("fs");
 
 function initCache(opts) {
   return 'var peg$resultsCache = {}';
@@ -978,7 +971,7 @@ function generateJavascript(ast, options) {
   }
 
 
-  var code = readSource('../../runtime/wrapper');
+  var code = fs.readFileSync(__dirname + '/' + '../../runtime/wrapper' + '.js', 'utf8');
   var parts = [];
 
   var cacheInitCode = '';
@@ -1000,12 +993,12 @@ function generateJavascript(ast, options) {
     '',
     cacheInitCode,
     '',
-    indent2(readSource('../../runtime/common-helpers')),
+    indent2(fs.readFileSync(__dirname + '/' + '../../runtime/common-helpers' + '.js', 'utf8')),
     '');
 
   if (options.trace) {
     parts.push(
-      indent2(readSource('../../runtime/trace-helpers')),
+      indent2(fs.readFileSync(__dirname + '/' + '../../runtime/trace-helpers' + '.js', 'utf8')),
       '');
   }
 
@@ -1071,7 +1064,7 @@ function generateJavascript(ast, options) {
 
   code = code.replace('/*$PARSER*/', function() {return indent2(parts.join('\n'));});
   code = code.replace('/*$TRACER*/', function() {
-    return options.trace ? readSource('../../runtime/tracer') : '';
+    return options.trace ? fs.readFileSync(__dirname + '/' + '../../runtime/tracer' + '.js', 'utf8') : '';
   });
   ast.code = code;
 }

--- a/lib/compiler/passes/stackvm-to-javascript.js
+++ b/lib/compiler/passes/stackvm-to-javascript.js
@@ -3,16 +3,9 @@
 var arrays = require("../../utils/arrays"),
     asts   = require("../asts"),
     op     = require("../opcodes"),
-    js     = require("../javascript");
-
-if (typeof window === 'undefined') {
-  var fs = require('fs');
-  var readSource = function (moduleName) {
-    var fileName = __dirname + '/' + moduleName + '.js';
-    return fs.readFileSync(fileName, 'utf8');
-  };
-}
-
+    js     = require("../javascript"),
+    fs     = require("fs");
+    
 function initCache(opts) {
   return 'var peg$resultsCache = {}';
 }
@@ -818,9 +811,9 @@ function generateJavascript(ast, options) {
       startRuleFunctions, startRuleFunction,
       ruleNames;
 
-  var code = readSource('../../runtime/wrapper');
+  var code = fs.readFileSync(__dirname + '/' + '../../runtime/wrapper' + '.js', 'utf8');
   code = code.replace('/*$TRACER*/',
-    function(){ return options.trace ? readSource('../../runtime/tracer') : ''; });
+    function(){ return options.trace ? fs.readFileSync(__dirname + '/' + '../../runtime/tracer' + '.js', 'utf8') : ''; });
 
   parts.push([
     '  function peg$parse(input) {',
@@ -934,7 +927,7 @@ function generateJavascript(ast, options) {
     ].join('\n'));
   }
 
-  parts.push(indent4(readSource('../../runtime/common-helpers')));
+  parts.push(indent4(fs.readFileSync(__dirname + '/' + '../../runtime/common-helpers' + '.js', 'utf8')));
 
   if (options.optimize === "size") {
     parts.push(indent4(generateInterpreter()));

--- a/lib/compiler/passes/stackvm-to-javascript.js
+++ b/lib/compiler/passes/stackvm-to-javascript.js
@@ -3,8 +3,8 @@
 var arrays = require("../../utils/arrays"),
     asts   = require("../asts"),
     op     = require("../opcodes"),
-    js     = require("../javascript"),
-    fs     = require("fs");
+    js     = require("../javascript");
+var fs     = require("fs");
     
 function initCache(opts) {
   return 'var peg$resultsCache = {}';

--- a/lib/runtime/browser-main.js
+++ b/lib/runtime/browser-main.js
@@ -8,12 +8,38 @@
  */
 var PEG = (function(undefined) {
   "use strict";
+
+  var endsWith = function(subjectString, searchString, position) {
+    if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.indexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+
+  var files = {
+    _content: {},
+    define: function(name, content) {
+      this._content[name] = content;
+    },
+    get: function(name) {
+      for (var key in this._content) {
+        if (endsWith(name, key))
+          return this._content[key];
+      }
+      return null;
+    }
+  };
+
   var modules = {
     define: function(name, factory) {
       var dir    = name.replace(/(^|\/)[^/]+$/, "$1"),
           module = { exports: {} };
 
       function require(path) {
+        if (path in modules)
+          return modules[name];
         var name   = dir + path,
             regexp = /[^\/]+\/\.\.\/|\.\//;
 
@@ -35,6 +61,11 @@ var PEG = (function(undefined) {
 
       factory(module, require, readSource);
       this[name] = module.exports;
+    },
+    fs: {
+      readFileSync: function(name, encoding) {
+          return files.get(name);
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "url":  "http://github.com/pegjs/pegjs.git"
   },
   "devDependencies": {
-    "browserify":   "11.2.0",
+    "brfs": "^1.4.2",
+    "browserify": "^13.0.0",
     "jasmine-node": "= 1.11.0",
     "uglify-js":    "= 2.4.7",
     "jshint":       "= 2.3.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "url":  "http://github.com/pegjs/pegjs.git"
   },
   "devDependencies": {
+    "browserify":   "11.2.0",
     "jasmine-node": "= 1.11.0",
     "uglify-js":    "= 2.4.7",
     "jshint":       "= 2.3.0"

--- a/tools/build-browser.js
+++ b/tools/build-browser.js
@@ -57,9 +57,9 @@ for (i = 0; i < modules.length; i++) {
 for (i = 0; i < runtimeModules.length; i++) {
   var moduleSource = readSource(runtimeModules[i]);
   moduleDefs.push(
-    '  modules.define(' + JSON.stringify(runtimeModules[i]) + ', function(module, require) {',
-    '    module.exports.code = ' + JSON.stringify(moduleSource),
-    '  });',
+    '  files.define(' + JSON.stringify(runtimeModules[i] + '.js') + ', ',
+    '    ' + JSON.stringify(moduleSource),
+    '  );',
   '');
 }
 


### PR DESCRIPTION
Background: I'm investigating a possible front-end use of Parsoid's JavaScript API and got here while sorting out some bundling and runtime issues. I intend to contribute bits (as I'm doing here) to Parsoid and related projects to ultimately solve some of these issues.

A common pattern when bundling npm modules for the browser is to replace calls to `fs.readFileSync` with the appropriate literal data, using [brfs](https://github.com/substack/brfs). Here, the trivial indirection via `readSource` was blocking `brfs` from transforming such calls even though the file names were hard-coded, so I rewrote those lines to use `fs.readFileSync` directly, and added a matching `fs` shim to `build-browser.js` for good measure.

For my workflow (`webpack`, `transform-loader`, `brfs`, thus actually bypassing `build-browser.js` entirely) I'm happy with just the above. But for simplicity's sake, for this PR I also cherry-picked the switch to `browserify` from upstream and added `brfs` to the build invocation, so `build-browser.js` is no longer used or needed.
